### PR TITLE
feat: add Pydantic power tools rule for SDA patterns

### DIFF
--- a/.cursor/rules/040-python-standards.mdc
+++ b/.cursor/rules/040-python-standards.mdc
@@ -10,7 +10,7 @@ alwaysApply: false
 - Never use `Any` if avoidable
 - Never use `getattr` with Pydantic models
 - Use `from typing import TYPE_CHECKING` for type-only imports
-- Modern Python 3.13+ syntax: `str | None` not `Optional[str]`
+- Modern Python 3.12+ syntax: `str | None` not `Optional[str]`
 
 ## Package Management
 - Use `uv add` for adding packages

--- a/.cursor/rules/070-pydantic-power-tools.mdc
+++ b/.cursor/rules/070-pydantic-power-tools.mdc
@@ -1,0 +1,51 @@
+---
+description: Pydantic's powerful tools that enable SDA patterns
+globs: ["**/*.py"]
+alwaysApply: false
+---
+
+# Pydantic Power Tools for SDA
+
+## Default to Pydantic Intelligence Over Procedural Checks
+
+### Replace isinstance() with Discriminated Unions
+- Use `Annotated[Union[...], Field(discriminator='type')]` for type dispatch
+- Let Pydantic handle type switching instead of manual checks
+- Tag types with `Literal` discriminator fields for automatic routing
+
+### Replace Manual Validation with Model Validators
+- Use `@field_validator` for single-field domain rules
+- Use `@model_validator` for cross-field business logic
+- Let models validate themselves instead of external validation functions
+
+### Replace Manual Serialization with Pydantic Operations
+- Use `model_validate()` instead of manual dict → object conversion
+- Use `model_dump()` instead of manual object → dict conversion
+- Use `TypeAdapter` to add Pydantic intelligence to any type
+
+## Core SDA Enablers
+
+### Domain Intelligence Tools
+- `@computed_field` for derived intelligence from other fields
+- `Field()` constraints for type-driven validation
+- `StrEnum` for behavioral enums with automatic conversion
+- `model_config = {"frozen": True}` for immutability
+- `model_copy(update={})` for immutable state transitions
+
+### Type System Power
+- `Self` for self-referential fluent APIs
+- `Generic` models for reusable domain patterns
+- Forward references for circular relationships
+- `Protocol` for external dependency contracts
+
+## The Pydantic Default Principle
+
+When you see:
+- **isinstance() checks** → Use discriminated unions
+- **Manual validation** → Use model validators
+- **External analyzers** → Use @computed_field domain intelligence
+- **Service classes** → Use domain methods on models
+- **Procedural transforms** → Use Pydantic serialization
+
+## Key Insight
+Pydantic eliminates the need for external logic by embedding intelligence directly in your domain models.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cp -r sda-rules-mdc-main/.cursor .
 
 ## What You Get
 
-Seven modular rules that work together:
+Eight modular rules that work together:
 
 ### [`000-sda-core.mdc`](.cursor/rules/000-sda-core.mdc) *(Always Applied)*
 Core architectural principles - data drives behavior, models contain business logic. The foundation that always loads.
@@ -49,6 +49,9 @@ Python-specific SDA requirements: type safety, modern syntax, package management
 
 ### [`060-reference-patterns.mdc`](.cursor/rules/060-reference-patterns.mdc) *(Context-Aware)*
 Concrete before/after transformation examples showing how to convert traditional patterns to SDA patterns.
+
+### [`070-pydantic-power-tools.mdc`](.cursor/rules/070-pydantic-power-tools.mdc) *(Context-Aware)*
+Pydantic's powerful tools that enable SDA patterns. Defaults to use discriminated unions, model validators, and domain intelligence instead of isinstance() checks and external validation.
 
 ## Token-Efficient Design
 
@@ -283,6 +286,34 @@ class PriceRange(BaseModel):
 ```
 
 The validator has access to all fields through `ValidationInfo`. Complex invariants become explicit constraints, impossible to violate regardless of how the model is constructed.
+
+## Key SDA Techniques
+
+### The Transformation Test
+Before writing any `if` statement, ask these questions:
+- Can this be type intelligence?
+- Can this be a model method?
+- Can this be enum behavior?
+- Can this be eliminated through better typing?
+
+This systematic approach transforms procedural code into declarative domain models.
+
+### System Boundary Principle
+The "Big Three" anti-patterns (isinstance(), hasattr()/getattr(), if/elif chains) are acceptable **ONLY** at true system boundaries:
+- Interfacing with external systems you don't control
+- Processing unknown data structures from APIs  
+- Working with framework/library objects
+- **NOT** for your own domain objects
+
+### Pydantic Power Tools
+Replace manual patterns with Pydantic intelligence:
+- **isinstance() checks** → Discriminated unions with `Field(discriminator='type')`
+- **Manual validation** → `@field_validator` and `@model_validator`
+- **External analyzers** → `@computed_field` domain intelligence
+- **Procedural transforms** → `model_validate()` and `model_dump()`
+
+### Testing Philosophy: The F1 Car
+SDA has sophisticated simplicity. Like an F1 car, complexity exists but it's necessary, elegant, and concentrated. Test the domain intelligence where it lives—in computed fields, enum behavior, and model decisions. Trust Pydantic for serialization, validation plumbing, and state management.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
Added new context-aware rule 070-pydantic-power-tools.mdc that guides AI to default to Pydantic's built-in intelligence instead of manual isinstance() checks and procedural validation patterns.

## Changes
- **NEW**: `.cursor/rules/070-pydantic-power-tools.mdc` - Pydantic SDA enablers
- **UPDATED**: README.md - Added rule description and comprehensive SDA techniques section
- **UPDATED**: `.cursor/rules/040-python-standards.mdc` - Fixed Python version to 3.12+

## Rule Content
The new rule provides directional guidance for:
- Replacing isinstance() checks with discriminated unions
- Using model validators instead of external validation functions
- Leveraging @computed_field for domain intelligence
- Defaulting to Pydantic serialization over manual transforms

## README Enhancements
Added "Key SDA Techniques" section covering:
- The Transformation Test framework
- System Boundary Principle for when anti-patterns are acceptable
- Pydantic Power Tools replacement patterns
- F1 Car testing philosophy

## Benefits
- **Focused Guidance**: Context-aware rule only loads when working with Pydantic
- **Clear Defaults**: AI knows to reach for Pydantic tools over procedural patterns
- **Complete Coverage**: README now comprehensively covers all rule concepts
- **Practical**: Actionable directives rather than theoretical explanations