### PR TITLE
feat: enforce explicit StrEnum usage over string literals across all …

### DIFF
--- a/.cursor/rules/000-sda-core.mdc
+++ b/.cursor/rules/000-sda-core.mdc
@@ -22,7 +22,7 @@ Data drives behavior. Business logic lives with the data it operates on.
 
 ## Decision Framework
 - Primitive with domain meaning? → Value Object (BaseModel)
-- Finite choices with behavior? → Enum with methods
+- Finite choices with behavior? → StrEnum with methods (never string literals)
 - Derived from other fields? → @computed_field
 - External dependency? → Protocol
 - Infrastructure coordination? → Service

--- a/.cursor/rules/010-anti-patterns.mdc
+++ b/.cursor/rules/010-anti-patterns.mdc
@@ -19,7 +19,8 @@ alwaysApply: false
 
 ## Enum Anti-Patterns
 - Never call `.value` on enums (defeats the purpose)
-- Use `StrEnum` for automatic string conversion
+- **Never use string literals** - Create `StrEnum` instead
+- Use `StrEnum` for automatic string conversion and behavioral methods
 - Add behavioral methods to enums, don't extract values
 
 ## Model Anti-Patterns

--- a/.cursor/rules/020-conditional-elimination.mdc
+++ b/.cursor/rules/020-conditional-elimination.mdc
@@ -10,10 +10,11 @@ alwaysApply: false
 Replace conditional chains with dictionary-based dispatch:
 - Multiple `if` checks → Mapping with behavioral methods
 - `isinstance()` chains → Discriminated unions with literal tags
-- Status-based logic → Enum methods
+- Status-based logic → StrEnum methods (never string literals)
 
 ## Behavioral Enums Replace Conditionals
 Instead of checking enum values in if-statements:
+- **Create StrEnum, never use string literals** for domain concepts
 - Add methods to enums that know their own behavior
 - Use enum state transition methods
 - Eliminate external conditional logic

--- a/.cursor/rules/040-python-standards.mdc
+++ b/.cursor/rules/040-python-standards.mdc
@@ -27,4 +27,4 @@ alwaysApply: false
 - Use protocols as interface contracts
 - Avoid generic dicts and Any types
 - Value objects over primitive obsession
-- Behavioral enums over string literals
+- **StrEnum over string literals** - Never use bare strings for domain concepts

--- a/.cursor/rules/070-pydantic-power-tools.mdc
+++ b/.cursor/rules/070-pydantic-power-tools.mdc
@@ -28,7 +28,7 @@ alwaysApply: false
 ### Domain Intelligence Tools
 - `@computed_field` for derived intelligence from other fields
 - `Field()` constraints for type-driven validation
-- `StrEnum` for behavioral enums with automatic conversion
+- **`StrEnum` instead of string literals** - Domain concepts need behavioral enums
 - `model_config = {"frozen": True}` for immutability
 - `model_copy(update={})` for immutable state transitions
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Every mature codebase eventually develops the same disease. Your domain knowledg
 class Order:
     items: List[dict]
     total: float
-    status: str
+    status: str  # ❌ String literal instead of StrEnum
 
 # Logic scattered everywhere  
 class OrderService:
@@ -169,10 +169,10 @@ Each state transition returns a new instance. This isn't just functional program
 
 ### 4. Smart Enums
 
-Enums typically just name constants. But in your domain, those constants have relationships, rules, and behavior. Don't hide that knowledge in service classes:
+Never use string literals for domain concepts. Create StrEnum instead—these constants have relationships, rules, and behavior. Don't hide that knowledge in service classes:
 
 ```python
-class OrderStatus(Enum):
+class OrderStatus(StrEnum):  # ✅ StrEnum, not string literals
     DRAFT = "draft"
     PLACED = "placed"
     SHIPPED = "shipped"
@@ -186,7 +186,7 @@ class OrderStatus(Enum):
         return transitions.get(self, set())
 ```
 
-This enum doesn't just list statuses—it encodes your business workflow. The state machine lives where it belongs, making invalid transitions impossible to express.
+This StrEnum doesn't just list statuses—it encodes your business workflow. The state machine lives where it belongs, making invalid transitions impossible to express. **Never use bare strings like `"draft"` or `"placed"` directly in your code.**
 
 ## Real-World Example
 
@@ -201,9 +201,9 @@ class PaymentService:
             raise ValueError("Invalid amount")
         
         # Calculate fees
-        if payment_data['method'] == 'credit':
+        if payment_data['method'] == 'credit':  # ❌ String literal checks
             fee = payment_data['amount'] * 0.029 + 0.30
-        elif payment_data['method'] == 'ach':
+        elif payment_data['method'] == 'ach':  # ❌ String literal checks
             fee = 0.25
         # ... 200 more lines
 
@@ -249,12 +249,12 @@ Traditional polymorphism in Python requires isinstance checks, visitor patterns,
 from typing import Annotated, Discriminator
 
 class EmailNotification(BaseModel):
-    type: Literal["email"] = "email"
+    type: Literal["email"] = "email"  # ✅ Literal OK for discriminator tags
     to: Email
     subject: str
 
 class SmsNotification(BaseModel):
-    type: Literal["sms"] = "sms"
+    type: Literal["sms"] = "sms"  # ✅ Literal OK for discriminator tags
     to: PhoneNumber
     message: str
 
@@ -266,6 +266,8 @@ def send(notification: Notification) -> None:
 ```
 
 The discriminator field tells Pydantic which type to instantiate. No manual type checking, no visitor pattern, no match statements. The type system handles dispatch automatically.
+
+**Note**: `Literal` is acceptable for discriminator tags in unions, but use `StrEnum` for actual domain concepts with behavior.
 
 ### Cross-Field Validation
 


### PR DESCRIPTION
…SDA rules

## Summary
Strengthened guidance to explicitly prohibit string literals for domain concepts and mandate StrEnum creation instead. Updated all rules files and README to provide clear, unambiguous direction for AI and developers.

## Changes Made

### Rules Files Updated:
- **000-sda-core.mdc**: Decision framework now specifies "StrEnum with methods (never string literals)"
- **010-anti-patterns.mdc**: Added "**Never use string literals** - Create `StrEnum` instead"
- **020-conditional-elimination.mdc**: Enhanced behavioral enum guidance with explicit StrEnum requirements
- **040-python-standards.mdc**: Changed to "**StrEnum over string literals** - Never use bare strings for domain concepts"
- **070-pydantic-power-tools.mdc**: Emphasized "**`StrEnum` instead of string literals** - Domain concepts need behavioral enums"

### README Documentation Updated:
- **Anemic model example**: Highlighted `status: str` as anti-pattern with explanatory comment
- **Smart Enums section**: Rewritten to lead with "Never use string literals" and show StrEnum best practices
- **Payment service example**: Added comments identifying string literal checks as anti-patterns
- **Discriminated unions**: Clarified when Literal is acceptable (discriminator tags) vs StrEnum (domain concepts)

## Key Principles Established

1. **Zero Tolerance**: Never use string literals for domain concepts
2. **Clear Alternative**: Always create StrEnum for finite domain choices
3. **Behavioral Focus**: Domain concepts need methods, not just values
4. **Legitimate Exception**: Literal types only for discriminator tags in unions

## Benefits
- **Eliminates Ambiguity**: AI and developers have clear guidance on enum usage
- **Prevents Anti-Patterns**: Explicit warnings against string literal usage
- **Promotes Domain Intelligence**: Encourages behavioral enums over static values
- **Consistent Messaging**: Unified approach across all documentation and rules

This change transforms vague "prefer enums" guidance into explicit "never use string literals, always create StrEnum" directives that eliminate common domain modeling mistakes.